### PR TITLE
Allow setting HSTS max-age to zero

### DIFF
--- a/lib/Plack/Middleware/RedirectSSL.pm
+++ b/lib/Plack/Middleware/RedirectSSL.pm
@@ -30,7 +30,7 @@ sub call {
 
 	my $res = $self->app->( $env );
 
-	if ( $is_ssl and $self->hsts ) {
+	if ( $is_ssl and defined $self->hsts and length $self->hsts ) {
 		my $max_age = 0 + $self->hsts;
 		$res = Plack::Util::response_cb( $res, sub {
 			my $res = shift;
@@ -82,7 +82,7 @@ be redirected to plain C<http>.
 
 Specifies the C<max-age> value for the C<Strict-Transport-Security> header.
 (Cf. L<RFCE<nbsp>6797, I<HTTP Strict Transport Security>|http://tools.ietf.org/html/rfc6797>.)
-If not specified, it defaults to 26 weeks. If 0, no C<Strict-Transport-Security>
+If not specified, it defaults to 26 weeks. If C<''> or C<undef>, no C<Strict-Transport-Security>
 header will be sent.
 
 =back

--- a/t/redirectssl.t
+++ b/t/redirectssl.t
@@ -2,7 +2,7 @@ use strict; use warnings;
 
 use Plack::Test;
 use Plack::Builder;
-use Test::More tests => 21;
+use Test::More tests => 22;
 use HTTP::Request::Common;
 use Plack::Middleware::RedirectSSL ();
 
@@ -67,7 +67,11 @@ test_psgi app => $mw->to_app, client => sub {
 	$res = $cb->( GET 'https://localhost/' );
 	is $res->header( 'Strict-Transport-Security' ), 'max-age='.$hsts_age, '... but can be changed';
 
-	$mw->hsts( 0 );
+	$mw->hsts( $hsts_age = 0 );
+	$res = $cb->( GET 'https://localhost/' );
+	is $res->header( 'Strict-Transport-Security' ), 'max-age='.$hsts_age, '... and also set to zero';
+
+	$mw->hsts( '' );
 	$res = $cb->( GET 'https://localhost/' );
 	is $res->header( 'Strict-Transport-Security' ), undef, '... or completely disabled';
 };


### PR DESCRIPTION
As https://tools.ietf.org/html/rfc6797#section-6.1.1 defines `max-age=0` can be used to actively de-publish the HSTS policy.